### PR TITLE
use relative_url to support https + cname pages

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ page.title | default: site.title | default: site.github.repository_name }}</title>
-    <link href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | absolute_url }}" rel="stylesheet">
+    <link href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}" rel="stylesheet">
   </head>
   <body>
     <div class="container">


### PR DESCRIPTION
For Pages with CNAMEs fronted by an HTTPS-enabled CDN, it would be better not to use absolute urls for links like CSS, since these default to using "HTTP" unless a different url is specified in the _config.yml.