### PR TITLE
Use responsive container class

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,7 +7,7 @@
     <link href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}" rel="stylesheet">
   </head>
   <body>
-    <div class="container markdown-body my-5">
+    <div class="container-lg px-3 my-5 markdown-body">
       {% if site.title and site.title != page.title %}
         <h1><a href="{{ "/" | absolute_url }}">{{ site.title }}</a></h1>
       {% endif %}


### PR DESCRIPTION
This updates the container class from `container` (fixed-width) to `container-lg px-3` (large with max-width + horizontal padding), [as suggested in the styleguide](https://github.com/styleguide/css/styles/core/objects/grid#containers). I thought that [`p-responsive`](https://github.com/styleguide/css/styles/core/utilities/padding#responsive-container-padding) might work here, but we might need to get a more recent version of Primer from npm to get that class, because it doesn't appear to be in the build on the most recently published site.

Also, I think that using `container-md`, with a max-width of 768px, might offer better legibility by reducing the line length:

| `container-lg` | `container-md` |
| :--- | :--- |
| ![image](https://user-images.githubusercontent.com/113896/28328829-9daadf50-6b9c-11e7-9e9a-c4b1e602640e.png) | ![image](https://user-images.githubusercontent.com/113896/28328805-8eb2a906-6b9c-11e7-88c9-ae98361e588b.png) |
