### PR TITLE
Add help improve this page link to footer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,7 @@ github:
   source:
     branch: "master"
     path: "/"
-
+  repository_url: "https://github.com/pages-themes/primer"
+  
 title: Jekyll Theme Primer
-description: Primer is a Jekyll theme for GitHub Pages 
+description: Primer is a Jekyll theme for GitHub Pages

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,7 +16,7 @@
       {{ content }}
 
       {% if site.github.private != true and site.github.license %}
-      <div class="footer border-top border-gray-light mt-5 pt-1 text-right text-small">
+      <div class="footer border-top border-gray-light mt-5 pt-3 text-right text-gray">
         This site is open source. <a href="{{ site.github.repository_url }}/edit/{{ site.github.source.branch }}{{ site.github.source.path }}{{ page.path }}">Help improve this page</a>.
       </div>
       {% endif %}


### PR DESCRIPTION
Pending https://github.com/github/help-docs/pull/5880 and https://github.com/github/pages/pull/1602, this PR adds a "help improve this page" button to the bottom of the default Pages theme if:

1. The repo is public, and 
2. The repo has an open source license

This is the last part of the [targeted Primer theme improvements](https://github.com/github/pages/issues/1501). Here's what it looks like in action:

<img width="1028" alt="screen shot 2017-08-15 at 4 03 49 pm" src="https://user-images.githubusercontent.com/282759/29333917-88f6c482-81d3-11e7-97e7-1ae8cdae64ef.png">

@jglovier, @jasonlong I know you both ❤️ open source, do you have any suggestions on the design? Since this is the default theme, I was trying to be as minimal/neutral via utility classes as possible, but open to suggestions if you have any.

/cc @parkr for the wording and overall "code"