### PR TITLE
fix file format typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ google_analytics: [Your Google Analytics tracking ID]
 
 If you'd like to add your own custom styles:
 
-1. Create a file called `/assets/css/style.css` in your site
+1. Create a file called `/assets/css/style.scss` in your site
 2. Add the following content to the top of the file, exactly as shown:
     ```scss
     ---


### PR DESCRIPTION
I spent quite a while trying to figure out why my custom CSS wasn't working. I found that the file format should be `.scss` rather than `.css`. 

Here is an article on GitHub that helped me figure out the problem.

https://help.github.com/articles/customizing-css-and-html-in-your-jekyll-theme/