### PR TITLE
Remove non-ascii characters from scss files

### DIFF
--- a/_sass/primer-support/lib/mixins/typography.scss
+++ b/_sass/primer-support/lib/mixins/typography.scss
@@ -40,7 +40,7 @@
 }
 
 // Responsive heading mixins
-// There are no responsive mixins for h4—h6 because they are small
+// There are no responsive mixins for h4-h6 because they are small
 // and don't need to be smaller on mobile.
 @mixin f1-responsive {
   font-size: $h1-size-mobile;

--- a/_sass/primer-support/lib/variables/typography.scss
+++ b/_sass/primer-support/lib/variables/typography.scss
@@ -2,7 +2,7 @@
 // stylelint-disable declaration-bang-space-before
 
 // Heading sizes - mobile
-// h4—h6 remain the same size on both mobile & desktop
+// h4-h6 remain the same size on both mobile & desktop
 $h00-size-mobile: 40px !default;
 $h0-size-mobile: 32px !default;
 $h1-size-mobile: 26px !default;


### PR DESCRIPTION
Replace em dashes with hyphens so these files are ascii characters only. These files have been producing an error in my jekyll site.

    Conversion error: Jekyll::Converters::Scss encountered an error while converting 'assets/css/style.scss':
                      Invalid US-ASCII character "\xE2" on line 5

This can be fixed by setting `LANG=en_US.UTF-8` in the terminal environment, but removing this unnecessary utf8 will more widely fix the problem.