### PR TITLE
Version bump for anchor.js

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -22,7 +22,7 @@
       </div>
       {% endif %}
     </div>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.1.0/anchor.min.js" integrity="sha256-lZaRhKri35AyJSypXXs4o6OPFTbTmUoltBbDCbdzegg=" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.2.2/anchor.min.js" integrity="sha384-6dhz+LFvhiM4G9QxNyE07x2m2kV0EVfSRSnAaLtTNFSAMe2GA0MGr9r3Yghs03FG" crossorigin="anonymous"></script>
     <script>anchors.add();</script>
     {% if site.google_analytics %}
     <script>


### PR DESCRIPTION
As discussed in [this issue](https://github.com/bryanbraun/anchorjs/issues/94) and closed in [this commit](https://github.com/bryanbraun/anchorjs/commit/7e560a4a2f026361fd23c021703d698d01b36970), anchor had a problem with URL-unsafe characters in IDs that was fixed after the version used by primer was released. This PR bumps the CDN version of anchors to 4.2.2, which fixes the error.