### PR TITLE
Add underlines to links

### DIFF
--- a/_sass/primer-base/lib/base.scss
+++ b/_sass/primer-base/lib/base.scss
@@ -22,7 +22,6 @@ body {
 
 a {
   color: $text-blue;
-  text-decoration: none;
 
   &:hover {
     text-decoration: underline;

--- a/_sass/primer-base/lib/base.scss
+++ b/_sass/primer-base/lib/base.scss
@@ -21,11 +21,7 @@ body {
 }
 
 a {
-  color: $text-blue;
-
-  &:hover {
-    text-decoration: underline;
-  }
+  color: $text-blue; 
 }
 
 b,

--- a/jekyll-theme-primer.gemspec
+++ b/jekyll-theme-primer.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'html-proofer', '~> 3.0'
   s.add_development_dependency 'rubocop', '~> 0.50'
   s.add_development_dependency 'w3c_validators', '~> 1.3'
+  s.required_ruby_version = '~> 2.6'
 end


### PR DESCRIPTION
This is necessary for good web accessibility and compliance with WCAG 2.0.

Basically, if a link is only identified by color, it can't be used by people with vision issues.


"Compliance F73: Failure of Success Criterion 1.4.1 due to creating links that are not visually evident without color vision"