### PR TITLE
Added data file for test with benbalter/jekyll-remote-theme

### DIFF
--- a/_data/greetings.yml
+++ b/_data/greetings.yml
@@ -1,0 +1,1 @@
+foo: "Hello from remote theme!"


### PR DESCRIPTION
Upcoming releases of Jekyll will be able to read data files from within themes ([see PR](https://github.com/jekyll/jekyll/pull/8815)). Another [pending PR](https://github.com/benbalter/jekyll-remote-theme/pull/89) will enable reading data files from remote themes.

To make a positive test for the latter I will need a `_data` folder within the [Primer](https://github.com/pages-themes/primer) theme. So I do propose to include a minimal sample to be able to enhance the tests at [https://github.com/benbalter/jekyll-remote-theme](https://github.com/benbalter/jekyll-remote-theme).