### PR TITLE
Add Support for inline latex via MathJax

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,4 +26,16 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.1.0/anchor.min.js" integrity="sha256-lZaRhKri35AyJSypXXs4o6OPFTbTmUoltBbDCbdzegg=" crossorigin="anonymous"></script>
     <script>anchors.add();</script>
   </body>
+  
+  <script type="text/javascript" id="MathJax-script" async
+        src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js">
+</script>
+
+<script>
+  MathJax = {
+    tex: {
+      inlineMath: [['$', '$']]
+    }
+  };
+</script>
 </html>


### PR DESCRIPTION
Would there be any interest in configuring Mathjax for this template by default? I am currently using jbsooter/primer to support this functionality for inline latex on GitHub pages. With GitHub supporting inline latex on all markdown documents, it would be nice if this came enabled out of the box for GitHub pages Jekyll templates as well. 

**What was changed in this fork:** 

Addition of Mathjax script and configuration of inline escape characters. See [this thread.](https://stackoverflow.com/questions/34347818/using-mathjax-on-a-github-page/72931039#72931039)

```
   <script type="text/javascript" id="MathJax-script" async
         src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js">
 </script>

 <script>
   MathJax = {
     tex: {
       inlineMath: [['$', '$']]
     }
   };
 </script>
```
