### PR TITLE
feat: Add 'footer_text' to site configuration

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,7 +19,7 @@
 
       {% if site.github.private != true and site.github.license %}
       <div class="footer border-top border-gray-light mt-5 pt-3 text-right text-gray">
-        This site is open source. {% github_edit_link "Improve this page" %}.
+        {{ site.footer_text | default: "This site is open source." }} {% github_edit_link "Improve this page" %}.
       </div>
       {% endif %}
     </div>


### PR DESCRIPTION
This pull request introduces a new `footer_text` variable in the site configuration. Users can now customize the footer text on their site by setting this variable in their `_config.yml` file.