### PR TITLE
feat: Enable custom footer through 'footer-custom.html'

### DIFF
--- a/_includes/footer-custom.html
+++ b/_includes/footer-custom.html
@@ -1,0 +1,5 @@
+{% if site.github.private != true and site.github.license %}
+<div class="footer border-top border-gray-light mt-5 pt-3 text-right text-gray">
+  This site is open source. {% github_edit_link "Improve this page" %}.
+</div>
+{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,12 +16,8 @@
       {% endif %}
 
       {{ content }}
-
-      {% if site.github.private != true and site.github.license %}
-      <div class="footer border-top border-gray-light mt-5 pt-3 text-right text-gray">
-        This site is open source. {% github_edit_link "Improve this page" %}.
-      </div>
-      {% endif %}
+      
+      {% include footer-custom.html %}
     </div>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.1.0/anchor.min.js" integrity="sha256-lZaRhKri35AyJSypXXs4o6OPFTbTmUoltBbDCbdzegg=" crossorigin="anonymous"></script>
     <script>anchors.add();</script>


### PR DESCRIPTION
This pull request allows users to customize the footer of their Jekyll site. By adding a 'footer-custom.html' file in the `_includes` directory of their repository, users can overwrite the default footer with their own content.
