### PR TITLE
docs: fix index large image

### DIFF
--- a/index.md
+++ b/index.md
@@ -98,7 +98,7 @@ end
 
 ### Large image
 
-![Branching](https://guides.github.com/activities/hello-world/branching.png)
+![Branching](https://docs.github.com/assets/cb-34248/mw-1440/images/help/repository/repo-create-global-nav-update.webp)
 
 
 ### Definition lists can be used with HTML syntax.


### PR DESCRIPTION
This pull request fixes the broken large image found in the example GitHub pages site.
