### PR TITLE
Convert Universal Analytics tracking code to Google Analytics 4

### DIFF
--- a/_includes/head-custom-google-analytics.html
+++ b/_includes/head-custom-google-analytics.html
@@ -1,10 +1,9 @@
 {% if site.google_analytics %}
+  <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
   <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', '{{ site.google_analytics }}', 'auto');
-    ga('send', 'pageview');
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){window.dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', '{{ site.google_analytics }}');
   </script>
 {% endif %}


### PR DESCRIPTION
Google Analytics' **Universal Analytics** has been switched off, in favor of their new **Google Analytics 4**, which [requires different tracking code](https://support.google.com/analytics/answer/10271001).

While Primer allows [customizing the tracker code](https://github.com/pages-themes/primer/blob/748f4ec7d1c3f96037d5c861395c7a5909353a52/README.md#customizing-google-analytics-code) by adding `_includes/head-custom-google-analytics.html` into each site's files, fixing this in the theme code will eliminate that need for most GitHub Pages users.

Remember that Primer is the default theme for GitHub Pages.