### PR TITLE
Fix usage example code in README.md to prevent error

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To use the Primer theme:
 1. Add the following to your site's `_config.yml`:
 
     ```yml
-    remote_theme: pages-themes/primer@v0.2.0
+    remote_theme: pages-themes/primer@v0.6.0
     plugins:
     - jekyll-remote-theme # add this line to the plugins list if you already have one
     ```


### PR DESCRIPTION
Bump version in example code so it doesn't give "url not found" error

The Error a user may get:

```
Remote Theme: Using theme pages-themes/primer                                                                                                                                  
jekyll 3.9.3 | Error:  404 - Not Found -
Loading URL: https://codeload.github.com/pages-themes/primer/zip/v0.2.0
/opt/homebrew/lib/ruby/gems/3.1.0/gems/jekyll-remote-theme-0.4.3/lib/jekyll-remote-theme/downloader.rb:67:in `raise_unless_sucess': 404 - Not Found - Loading URL: https://codeload.g ithub.com/pages-themes/primer/zip/v0.2.0 (Jekyll::RemoteTheme::DownloadError)
```