### PR TITLE
Use <footer> in place of <div>

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,9 +18,9 @@
       {{ content }}
 
       {% if site.github.private != true and site.github.license %}
-      <div class="footer border-top border-gray-light mt-5 pt-3 text-right text-gray">
+      <footer class="footer border-top border-gray-light mt-5 pt-3 text-right text-gray">
         This site is open source. {% github_edit_link "Improve this page" %}.
-      </div>
+      </footer>
       {% endif %}
     </div>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.1.0/anchor.min.js" integrity="sha256-lZaRhKri35AyJSypXXs4o6OPFTbTmUoltBbDCbdzegg=" crossorigin="anonymous"></script>


### PR DESCRIPTION
This is a low-hanging fruit. Semantic tags improve accessibility, and there’s no cosmetic change involved in this case.

A remaining issue is the duplicate \<h1> tags: one from site name, and a second one from first-level heading:
```html
    <div class="container-lg px-3 my-5 markdown-body">
      
      <h1><a href="https://pages-themes.github.io/primer/">Jekyll Theme Primer</a></h1>
      

      <p>Text can be <strong>bold</strong>, <em>italic</em>, or <del>strikethrough</del>.</p>

<p><a href="./another-page.html">Link to another page</a>.</p>

<p>There should be whitespace between paragraphs.</p>

<p>There should be whitespace between paragraphs. We recommend including a README, or a file with information about your project.</p>

<h1 id="header-1">Header 1</h1>
 ```
A good solution would be to enclose the first inside a \<header> or \<nav>, and {{ content }} inside a \<main>, since it’s idiomatic for different sections to get their own \<h1>.

Example from other themes: https://github.com/cotes2020/jekyll-theme-chirpy/pull/1207.