### PR TITLE
Add boilerplate for content security policy

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta http-equiv="Content-Security-Policy" content="style-src 'self' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='; script-src 'sha256-imF8GK2COF0FH3k9XZpauIkklApKaavS3S5BhNoXbio=' 'sha256-lZaRhKri35AyJSypXXs4o6OPFTbTmUoltBbDCbdzegg='; font-src data:">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
 {% seo %}


### PR DESCRIPTION
The `meta` element is used since Pages sites can’t edit response headers.

It’s a boilerplate in the sense that it works out of box and doesn’t restrict where the user sources their images. Only directives allowing AnchorJS and its embedded styles have been added.